### PR TITLE
Add the "Development tools" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Awesome Uxn
-Awesome things from the community
+
+Awesome things from the community.
 
 ## Community
 
@@ -11,18 +12,33 @@ Awesome things from the community
 
 ## Emulators
 
-- [Playdate](https://git.sr.ht/~rabbits/uxn-playdate)
-- [NintendoDS](https://github.com/asiekierka/uxnds)
 - [Browser](https://github.com/aduros/webuxn)
-- [Gameboy Advance](https://git.badd10de.dev/uxngba)
-- [Vita](https://github.com/ivodopiviz/uxnvita)
+- [Game Boy Advance](https://git.badd10de.dev/uxngba)
+- [Nintendo DS](https://github.com/asiekierka/uxnds)
+- [Playdate](https://git.sr.ht/~rabbits/uxn-playdate)
+- [PlayStation Vita](https://github.com/ivodopiviz/uxnvita)
+- [Rasperry Pi Pico](https://merveilles.town/@alderwick/106222101764116637)
 - [Teletype](https://github.com/csboling/teluxn)
 
-## Assemblers
+## Development tools
 
-- [Rust](https://github.com/karolbelina/ruxnasm)
+### IDEs
 
-## Syntax Highlight
+- [Learn Uxn](https://metasyn.github.io/learn-uxn/)
 
-- [Vim](https://github.com/karolbelina/uxntal.vim)
-- [micro](https://nilfm.cc/git/dotfiles/tree/micro/syntax/uxn.yaml)
+### Assemblers & compilers
+
+- [Ruxnasm](https://github.com/karolbelina/ruxnasm)
+- [Uxncle](https://github.com/CPunch/Uxncle)
+- [Uxntal test suite](https://github.com/karolbelina/uxntal-test-suite)
+
+### Uxntal language support
+
+- [Emacs mode](https://github.com/xaderfos/uxntal-mode)
+- [Micro syntax](https://nilfm.cc/git/dotfiles/tree/micro/syntax/uxn.yaml)
+- [Vim plugin](https://github.com/karolbelina/uxntal.vim)
+- [Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=karolbelina.uxntal)
+
+## Applications
+
+- [Bad Apple!!](https://github.com/karolbelina/bad-apple-uxn)


### PR DESCRIPTION
This pull request merges the development tools into a single section, which includes the integrated development environments (just one for now), the assemblers & compilers along with language testing environments, as well as Uxntal language support for various text editors. I've also added the Applications section for software that can be ran on Uxn emulators, and included some more projects from the community.