### PR TITLE
Add Kakoune syntax project to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
 
   - [Emacs mode](https://github.com/xaderfos/uxntal-mode)
   - [Emacs mode (alt)](https://github.com/rafapaezbas/uxntal-mode)
+  - [Kakoune syntax](https://git.sr.ht/~athorp96/uxntal.kak)
   - [Micro syntax](https://nilfm.cc/git/dotfiles/tree/micro/syntax/uxn.yaml)
   - [Sublime syntax](https://git.sr.ht/~rabbits/uxn/tree/main/item/etc/tal.sublime-syntax)
   - [Vim plugin](https://github.com/karolbelina/uxntal.vim)


### PR DESCRIPTION
This adds my new [Kakoune](https://kakoune.org/) [uxntal syntax plugin](https://git.sr.ht/~athorp96/uxntal.kak) to Development Tools/Uxntal Language Support. The linked repository is mirrored on [github](https://github.com/athorp96/uxntal.kak) so if you'd prefer to link to that mirror instead that would be at your discretion. However the plugin's documentation does exclusively use the Sourcehut mirror. 

Thanks! 