### PR TITLE
add the auxn implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
   - [Logisim](https://github.com/DeltaF1/uxn-logisim) - Incomplete.
   - [Adafruit PyBadge](https://git.sr.ht/~poyu/uxn-pybadge) - Implemented: Core, Console, Screen, Controller.
   - [Webuxn](https://github.com/aduros/webuxn) - Lightweight port of the Uxn virtual machine to the web via WebAssembly.
+  - [auxn](https://github.com/saucesaft/auxn) - uxn running inside of an audio plugin (standalone mode included)
 
 * Simulator
 


### PR DESCRIPTION
hi! I've been working on a reimplementation of uxn in rust with the added feature of it being able to run as a VST3 or CLAP audio plugin, i added it to the misc. section altough im not sure if that category is right. maybe should i move it to desktop? thanks