### PR TITLE
add arg.tal for command-line argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
   - [regex](http://plastic-idolatry.com/erik/nxu/regex.tal) - Regex parsing and matching ([repl](http://plastic-idolatry.com/erik/nxu/repl-regex.tal))
   - [fix16](http://plastic-idolatry.com/erik/nxu/fix16.tal) - Signed 16-bit fixed point numbers (8.8)
   - [alloc](http://plastic-idolatry.com/erik/nxu/alloc.tal) - Arena-based memory allocator
+  - [arg](http://plastic-idolatry.com/erik/nxu/arg.tal) - Command-line argument parsing ([demo](http://plastic-idolatry.com/erik/nxu/alloc-demo.tal))
 
 * Terminal / Command-line
 


### PR DESCRIPTION
This code uses the new `.Console/type` register to make parsing command-line arguments a lot easier.

In particular it allows authors to validate the number of arguments they receive (as well as the string values of those arguments) all in one place.

It also includes a simple demo program showing how to use the library.