### PR TITLE
Add ruxn.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
   - [UxnLua](https://github.com/DeltaF1/uxn-lua) - Cross-platform emulator, written in Lua(Love2d).
   - [Uxn38](http://zzo38computer.org/fossil/uxn.ui) - Emulator written in C with SDL1.
   - [Nux](https://github.com/nf/nux) - Emulator written in Go.
+  - [ruxn](https://github.com/CrashAndSideburns/ruxn) - A Uxn library written in Rust, intended to make defining new Uxn-based systems easy.
 
 * Other systems
 


### PR DESCRIPTION
I finally managed to write a large enough test suite for my Uxn implementation that I'm willing to show it to people. `ruxn` is not an emulator attempting to emulate Varvara, unlike many of the other projects under the "Emulators" heading, so I'm not sure if it would be better placed elsewhere. The goal of `ruxn` is to provide an abstracted emulator for the Uxn CPU (and only the CPU) with the goal of making it easy for people to emulate a variety of Uxn-based systems simply by defining the semantics of the attached devices. I do hope to write a Varvara implementation based on `ruxn` at some point, but `ruxn` itself does not emulate Varvara.