### PR TITLE
Add zuxn to emulators section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
   - [Nux](https://github.com/nf/nux) - Emulator written in Go.
   - [uxn-rs](https://git.sr.ht/~liorst4/uxn-rs) - Emulator written in Rust.
   - [ruxn](https://github.com/CrashAndSideburns/ruxn) - A Uxn library written in Rust, intended to make defining new Uxn-based systems easy.
+  - [zuxn](https://github.com/chmod222/zuxn) - A Uxn library, emulator and assembler written in Zig.
 
 * Other systems
 


### PR DESCRIPTION
Adds a link to my implementation that I have been working on for the past 2 weeks.

While there is a teeny tiny extra-expansion in the varvara system device that is not sanctioned (so to say) by the reference (I really wanted to be able to retrieve environment variables because for some reason I plan on using the CLI emulator as a CGI script), it closely follows the developments of the official implementation.