### PR TITLE
Update reference to Bunnymark

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The [Uxn](https://100r.co/site/uxn.html) ecosystem is a personal computing playg
 
 ### Benchmarking
 
-  - [Bunnymark](https://codeberg.org/kira/uxn-demos/src/branch/master/bunnymark.tal) - Render performance benchmark.
+  - [Bunnymark](https://git.sr.ht/~rabbits/uxn/tree/main/item/projects/examples/demos/bunnymark.tal) - Render performance benchmark.
 
 ## Community
 


### PR DESCRIPTION
Old bunnymark is glitchy on newest varvara emulators, this works fine.