### PR TITLE
Add link to uxnasm-hs assembler

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Implementations of the core and console.
 - [Uxnasm-js](https://github.com/rafapaezbas/uxnasm-js) - Uxntal assembler written in JavaScript.
 - [lunas](https://github.com/ThaCuber/lunas) - An Uxntal assembler written in Lua.
 - [Yaku](https://codeberg.org/wimvanderbauwhede/yaku) - An Uxntal assembler and interpreter.
+- [uxnasm-hs](https://github.com/ricardomaps/uxnasm-hs) - Uxntal assembler written in Haskell
 
 ### Uxntal Disassemblers
 


### PR DESCRIPTION
I wrote a uxntal assembler in haskell that i think is pretty cool 
[uxnasm-hs](https://github.com/ricardomaps/uxnasm-hs)